### PR TITLE
Update blank to 4.19.19

### DIFF
--- a/contrib/config/sun50i.config
+++ b/contrib/config/sun50i.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.19.0-rc7 Kernel Configuration
+# Linux/arm64 4.19.19 Kernel Configuration
 #
 
 #
@@ -78,6 +78,7 @@ CONFIG_PREEMPT_COUNT=y
 CONFIG_TICK_CPU_ACCOUNTING=y
 # CONFIG_VIRT_CPU_ACCOUNTING_GEN is not set
 CONFIG_IRQ_TIME_ACCOUNTING=y
+CONFIG_HAVE_SCHED_AVG_IRQ=y
 CONFIG_BSD_PROCESS_ACCT=y
 CONFIG_BSD_PROCESS_ACCT_V3=y
 CONFIG_TASKSTATS=y
@@ -495,7 +496,6 @@ CONFIG_CRYPTO_AES_ARM64_CE_BLK=y
 # CONFIG_CRYPTO_AES_ARM64_NEON_BLK is not set
 # CONFIG_CRYPTO_CHACHA20_NEON is not set
 # CONFIG_CRYPTO_AES_ARM64_BS is not set
-# CONFIG_CRYPTO_SPECK_NEON is not set
 
 #
 # General architecture-dependent options
@@ -3074,6 +3074,7 @@ CONFIG_USB_BDC_UDC=y
 # CONFIG_USB_DUMMY_HCD is not set
 # CONFIG_USB_CONFIGFS is not set
 # CONFIG_TYPEC is not set
+# CONFIG_USB_ROLE_SWITCH is not set
 # CONFIG_USB_LED_TRIG is not set
 CONFIG_USB_ULPI_BUS=y
 # CONFIG_UWB is not set
@@ -4259,7 +4260,6 @@ CONFIG_CRYPTO_CHACHA20=m
 # CONFIG_CRYPTO_SEED is not set
 # CONFIG_CRYPTO_SERPENT is not set
 # CONFIG_CRYPTO_SM4 is not set
-# CONFIG_CRYPTO_SPECK is not set
 # CONFIG_CRYPTO_TEA is not set
 # CONFIG_CRYPTO_TWOFISH is not set
 

--- a/contrib/config/sun8i.config
+++ b/contrib/config/sun8i.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 4.19.0-rc2 Kernel Configuration
+# Linux/arm 4.19.19 Kernel Configuration
 #
 
 #
@@ -537,7 +537,6 @@ CONFIG_CRYPTO_AES_ARM_BS=y
 # CONFIG_CRYPTO_GHASH_ARM_CE is not set
 CONFIG_CRYPTO_CRC32_ARM_CE=y
 # CONFIG_CRYPTO_CHACHA20_NEON is not set
-# CONFIG_CRYPTO_SPECK_NEON is not set
 # CONFIG_VIRTUALIZATION is not set
 
 #
@@ -2874,6 +2873,7 @@ CONFIG_USB_GADGET_STORAGE_NUM_BUFFERS=2
 # CONFIG_USB_DUMMY_HCD is not set
 # CONFIG_USB_CONFIGFS is not set
 # CONFIG_TYPEC is not set
+# CONFIG_USB_ROLE_SWITCH is not set
 # CONFIG_USB_LED_TRIG is not set
 # CONFIG_USB_ULPI_BUS is not set
 # CONFIG_UWB is not set
@@ -3955,7 +3955,6 @@ CONFIG_CRYPTO_DES=y
 # CONFIG_CRYPTO_SEED is not set
 # CONFIG_CRYPTO_SERPENT is not set
 # CONFIG_CRYPTO_SM4 is not set
-# CONFIG_CRYPTO_SPECK is not set
 # CONFIG_CRYPTO_TEA is not set
 # CONFIG_CRYPTO_TWOFISH is not set
 

--- a/package.txt
+++ b/package.txt
@@ -1,9 +1,9 @@
 NAME=linux
-VERSION=4.19.0
-REVISION=11
+VERSION=4.19.19
+REVISION=12
 LICENSE=GPL-2.0-only
-SRC=https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.19.tar.xz
-SRCMD5=740a90cf810c2105df8ee12e5d0bb900
+SRC=https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.19.19.tar.xz
+SRCMD5=e6a678e1880ed366a860f537d82be247
 BUILDDEPS=bc libcap libelf openssl u-boot
 STRIP=no
 ALIASES=allh5cc|nanopik1plus|nanopineo2|nanopineoplus2|orangepipc2:sun50i allh3cc|nanopineo|nanopim1plus|orangepione|orangepipc|orangepilite:sun8i


### PR DESCRIPTION
Updating 'Blank' to 4.19.19 to address security and other issues. This update has been tested on Nano Pi Neo (sun8i ARMv7) and Nano Pi Neo 2 (sun50i ARMv8).